### PR TITLE
Add Tree, Surround, Splitjoin, and new remaps

### DIFF
--- a/dot-config/nvim/after/plugin/splitjoin.lua
+++ b/dot-config/nvim/after/plugin/splitjoin.lua
@@ -1,0 +1,16 @@
+local is_ruby_file = function()
+  return vim.fn.expand('%:e') == 'rb'
+end
+
+if is_ruby_file() then
+  vim.g.splitjoin_join_mapping = ''
+  vim.g.splitjoin_split_mapping = ''
+  vim.g.splitjoin_ruby_hanging_args = 0
+
+  -- Remaps for gb and gB mnemonic for block
+  vim.api.nvim_set_keymap('n', 'gB', [[:SplitjoinJoin<CR>]], { noremap = false, silent = true })
+  vim.api.nvim_set_keymap('n', 'gb', [[:SplitjoinSplit<CR>]], {
+    noremap = false,
+    silent = true,
+  })
+end

--- a/dot-config/nvim/after/plugin/tree.lua
+++ b/dot-config/nvim/after/plugin/tree.lua
@@ -1,0 +1,33 @@
+-- Disable Netrw
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1
+
+-- set termguicolors to enable highlight groups
+vim.opt.termguicolors = true
+
+local function my_on_attach(bufnr)
+  local api = require "nvim-tree.api"
+
+  local function opts(desc)
+    return { desc = "nvim-tree: " .. desc, buffer = bufnr, noremap = true, silent = true, nowait = true }
+  end
+
+  api.config.mappings.default_on_attach(bufnr)
+
+  -- custom remaps
+  vim.keymap.set('n', '<leader>cd', api.tree.change_root_to_node, opts('CD'))
+  vim.keymap.set('n', '<leader>..', api.tree.change_root_to_parent, opts('Up'))
+end
+
+-- empty setup using defaults
+require("nvim-tree").setup{
+  live_filter = {
+    prefix = "[FILTER]: ",
+    always_show_folders = false,
+  },
+  on_attach = my_on_attach,
+  update_focused_file = {
+    enable = true,
+  }
+}
+

--- a/dot-config/nvim/lua/core/packer.lua
+++ b/dot-config/nvim/lua/core/packer.lua
@@ -15,6 +15,13 @@ return require('packer').startup(function(use)
     }
   }
 
+  use {
+    'nvim-tree/nvim-tree.lua',
+    requires = {
+      'nvim-tree/nvim-web-devicons', -- Requires a NerdFont
+    },
+  }
+
   use({ 'sainnhe/gruvbox-material',
   	as = 'gruvbox-material',
 	config = function()
@@ -38,5 +45,8 @@ return require('packer').startup(function(use)
   use 'hrsh7th/cmp-nvim-lsp'
   use 'saadparwaiz1/cmp_luasnip'
   use 'L3MON4D3/LuaSnip'
+
+  use('AndrewRadev/splitjoin.vim')
+  use('tpope/vim-surround')
 
 end)

--- a/dot-config/nvim/lua/core/remap.lua
+++ b/dot-config/nvim/lua/core/remap.lua
@@ -1,7 +1,7 @@
 vim.g.mapleader = " "
 
 -- for netrw
-vim.keymap.set("n", "<leader>pv", vim.cmd.Ex)
+--vim.keymap.set("n", "<leader>pv", vim.cmd.Ex)
 
 -- for everything window
 vim.keymap.set("n", "<leader>w", "<C-w>")
@@ -12,3 +12,9 @@ vim.keymap.set("n", "<leader>r", "<C-r>")
 -- for copying to clipboard to paste outside of vim
 vim.keymap.set("n", "<leader>y", "\"+y")
 vim.keymap.set("v", "<leader>y", "\"+y")
+
+-- Enable nvim tree shortcut
+vim.keymap.set("n", "<leader>f", vim.cmd.NvimTreeToggle)
+
+-- Active File Directory expansion
+vim.cmd[[cnoremap <expr> %% getcmdtype() == ':' ? expand('%:h').'/' : '%%']]


### PR DESCRIPTION
Plugins added:
- Tree.nvim (replaces Netrw)
- Surround.vim 
- Splitjoin (only used for Ruby)

Also added some more remaps, particularly `%%` for directory expansion (useful for Tree and Telescope)